### PR TITLE
Fix cache 503 conflicts with explicit platform keys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,10 @@ jobs:
           components: clippy, rustfmt
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2.7.5
+        with:
+          key: ${{ runner.os }}-rust-${{ matrix.os }}
+          cache-on-failure: true
+          save-if: true
       - name: Build
         run: cargo build
       - name: Run tests


### PR DESCRIPTION
## Problem

The merged workflow is experiencing **cache 503 errors** when trying to save caches:

```
Warning: Failed to save: reserveCache failed: Cache service responded with 503
```

## Root Cause Analysis

Based on the `rust-cache` README, caches are automatically keyed by:
- `github job_id` 
- `rustc release/host/hash`
- Environment variables (RUSTFLAGS, etc)
- Hash of Cargo.lock/Cargo.toml files
- Hash of rust-toolchain files

**The issue**: When running a matrix build with 3 platforms simultaneously, there might be **cache key collisions** causing multiple platforms to compete for the same cache slot, resulting in HTTP 503 conflicts.

## Solution

Add **explicit cache key differentiation** per platform:

```yaml
- name: Setup Rust cache
  uses: Swatinem/rust-cache@v2.7.5
  with:
    key: ${{ runner.os }}-rust-${{ matrix.os }}
    cache-on-failure: true
    save-if: true
```

This creates unique cache keys:
- **Linux-rust-ubuntu-latest** 
- **Windows-rust-windows-latest**
- **macOS-rust-macos-latest**

## Additional Improvements

- `cache-on-failure: true` - Save cache even if build fails (useful for debugging)
- `save-if: true` - Ensure cache is saved when possible

## Expected Outcome

- ✅ **No more 503 cache conflicts**
- ✅ **Faster subsequent builds** with working cache
- ✅ **Platform-specific optimized caches**
- ✅ **Better debugging capabilities**

## Testing

This PR will test the fix by running the workflow and checking for:
1. Successful cache saves (no 503 errors)
2. Proper cache keys in logs
3. Expected build performance improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the Rust workflow caching in GitHub Actions to enhance cache reliability and performance during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->