### PR TITLE
Test actions/cache to isolate 503 cache issue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,12 +22,25 @@ jobs:
         with:
           toolchain: 1.87.0
           components: clippy, rustfmt
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2.7.5
+      - name: Cache cargo registry
+        uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-rust-${{ matrix.os }}
-          cache-on-failure: true
-          save-if: true
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target/
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-build-
       - name: Build
         run: cargo build
       - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,10 @@ jobs:
           components: clippy, rustfmt
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2.7.5
+        with:
+          key: ${{ runner.os }}-rust-${{ matrix.os }}
+          cache-on-failure: true
+          save-if: true
       - name: Build
         run: cargo build
       - name: Run tests


### PR DESCRIPTION
## Purpose

This PR tests whether the **cache 503 errors** are specific to `rust-cache` or a broader GitHub cache service issue.

## Hypothesis Testing

**Replace `rust-cache` with manual `actions/cache`** to isolate the problem:

```yaml
# Before: rust-cache (getting 503 errors)
- uses: Swatinem/rust-cache@v2.7.5

# After: Manual actions/cache setup
- uses: actions/cache@v4  # Cargo registry
- uses: actions/cache@v4  # Build artifacts
```

## Manual Cache Configuration

**Cargo Registry Cache:**
```yaml
path: |
  ~/.cargo/registry/index/
  ~/.cargo/registry/cache/
  ~/.cargo/git/db/
key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
```

**Build Artifacts Cache:**
```yaml
path: target/
key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}
```

## What This Will Tell Us

### If `actions/cache` works (no 503 errors):
- ✅ **Issue is with `rust-cache`** implementation
- ✅ GitHub's cache service is working fine
- ✅ Possible causes: rust-cache using deprecated APIs, bugs in rust-cache v2.7.5

### If `actions/cache` also gets 503 errors:
- ✅ **Issue is with GitHub's cache service** itself
- ✅ Not specific to rust-cache
- ✅ Broader infrastructure problem

## Expected Behavior

**First run**: No cache hits, builds from scratch, attempts to save caches
**If successful**: Should see cache save confirmations without 503 errors
**Subsequent runs**: Should restore caches and build faster

## Testing Strategy

1. **Monitor cache logs** for 503 errors
2. **Check cache save/restore** success messages  
3. **Compare performance** with previous runs
4. **Verify cache keys** are being generated correctly

This diagnostic approach will help us understand the root cause and determine the best long-term solution.