### PR TITLE
Optimize CI performance by skipping rust-analyzer installation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: 1.87.0
-          components: clippy, rustfmt
+        run: |
+          rustup toolchain install 1.87.0 --profile minimal --component clippy,rustfmt
+          rustup default 1.87.0
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Problem

CI was downloading and installing `rust-analyzer` (~100MB) even though it's not needed for CI - only for local development.

## Root Cause

The `rust-toolchain.toml` file lists all components needed for development:

```toml
[toolchain]
channel = "1.87.0"
profile = "minimal"
components = ["rust-analyzer", "clippy", "rustfmt"]
```

Even when overriding `components` in the workflow, `dtolnay/rust-toolchain` still reads the toolchain file and installs **all listed components**.

## Solution

Replace the action with **direct `rustup` commands** that ignore the toolchain file:

```yaml
# Before: Installs rust-analyzer unnecessarily
- uses: dtolnay/rust-toolchain@v1
  with:
    toolchain: 1.87.0
    components: clippy, rustfmt

# After: Only installs what CI needs
- name: Install Rust toolchain
  run: |
    rustup toolchain install 1.87.0 --profile minimal --component clippy,rustfmt
    rustup default 1.87.0
```

## Benefits

- ✅ **Faster CI** - Avoids downloading ~100MB rust-analyzer
- ✅ **Cleaner logs** - No unnecessary component installation messages
- ✅ **Same functionality** - Still gets Rust 1.87.0 with clippy and rustfmt
- ✅ **Local development unchanged** - rust-toolchain.toml still works for developers

## Performance Impact

**Before**: 
```
info: downloading component 'rust-analyzer'
info: installing component 'rust-analyzer'
```

**After**: 
Only downloads clippy and rustfmt (much smaller)

## Local Development

Developers will still get `rust-analyzer` when working locally because:
- `rustup` reads `rust-toolchain.toml` automatically
- IDEs (VS Code, etc.) use the local toolchain
- Only CI skips the unnecessary component

This gives us the best of both worlds - fast CI and full local development tooling.